### PR TITLE
:bug: Fix display of boxes

### DIFF
--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -4667,7 +4667,7 @@ div.tabBar .noborder {
 }
 .boxstats130 {
 	width: 135px;
-	height: 48px;
+	min-height: 48px;
 	padding: 3px
 }
 @media only screen and (max-width: 767px)


### PR DESCRIPTION
Only use  a minimum height instead of hard-coded height.

The current behavior hides links that may be further down the box.