### PR TITLE
:bug: Fix default colors

### DIFF
--- a/htdocs/custom/oblyon/admin/colors.php
+++ b/htdocs/custom/oblyon/admin/colors.php
@@ -218,7 +218,6 @@ $(document).ready(function() {
 		$("#dhfs-stor-val").val(rem_dhfs);
 		$("#tmenu_tooltip").css("font-size",rem_dhfs);
 		$(".login_block").css("font-size",rem_dhfs);
-		sizes_calc();
 	});
 
 	$("#shfs-slider").slider({
@@ -230,7 +229,6 @@ $(document).ready(function() {
 	$("#shfs-disp-val").html(act_px_shfs);
 	$("#shfs-stor-val").val(act_rem_shfs);
 	$("#shfs-slider").slider("value",act_shfs - def_shfs);
-	sizes_calc();
 	$("#shfs-slider").on("slide",function(event, ui) {
 		var shfs_sel_value = $("#shfs-slider").slider("value");
 		var new_shfs = def_shfs + shfs_sel_value;
@@ -266,7 +264,6 @@ $(document).ready(function() {
 	$("#svmfs-disp-val").html(act_px_svmfs);
 	$("#svmfs-stor-val").val(act_rem_svmfs);
 	$("#svmfs-slider").slider("value",act_svmfs - def_svmfs);
-	sizes_calc();
 	$("#svmfs-slider").on("slide",function(event, ui) {
 		var svmfs_sel_value = $("#svmfs-slider").slider("value");
 		var new_svmfs = def_svmfs + svmfs_sel_value;

--- a/htdocs/custom/oblyon/admin/colors.php
+++ b/htdocs/custom/oblyon/admin/colors.php
@@ -118,7 +118,7 @@ if ($action == 'settheme') {
 		dolibarr_set_const($db, "OBLYON_COLOR_MAIN", '#0083a2','chaine',0,'',$conf->entity);
 		dolibarr_set_const($db, "OBLYON_COLOR_TOPMENU_BCKGRD", '#333','chaine',0,'',$conf->entity);
 		dolibarr_set_const($db, "OBLYON_COLOR_TOPMENU_TXT", '#f4f4f4','chaine',0,'',$conf->entity);
-		dolibarr_set_const($db, "OBLYON_COLOR_TOPMENU_BCKGRD_HOVER", '#0083a2','chaine',0,'',$conf->entity);
+		dolibarr_set_const($db, "OBLYON_COLOR_TOPMENU_BCKGRD_HOVER", '#444','chaine',0,'',$conf->entity);
 		dolibarr_set_const($db, "OBLYON_COLOR_LEFTMENU_BCKGRD", '#333','chaine',0,'',$conf->entity);
 		dolibarr_set_const($db, "OBLYON_COLOR_LEFTMENU_TXT", '#f4f4f4','chaine',0,'',$conf->entity);
 		dolibarr_set_const($db, "OBLYON_COLOR_LEFTMENU_BCKGRD_HOVER", '#444','chaine',0,'',$conf->entity);

--- a/htdocs/custom/oblyon/core/modules/modOblyon.class.php
+++ b/htdocs/custom/oblyon/core/modules/modOblyon.class.php
@@ -165,7 +165,7 @@ function __construct($db) {
 	$r ++;
 	$this->const [$r] [0] = "OBLYON_COLOR_TOPMENU_BCKGRD_HOVER";
 	$this->const [$r] [1] = "chaine";
-	$this->const [$r] [2] = "#0083a2";
+	$this->const [$r] [2] = "#444444";
 	$this->const [$r] [3] = 'Oblyon background topmenu hover color';
 	$this->const [$r] [4] = 1;
 	$this->const [$r] [5] = 'allentities';
@@ -174,7 +174,7 @@ function __construct($db) {
 	$r ++;
 	$this->const [$r] [0] = "OBLYON_COLOR_TOPMENU_TXT";
 	$this->const [$r] [1] = "chaine";
-	$this->const [$r] [2] = "#f4f4f4";
+	$this->const [$r] [2] = "#F4F4F4";
 	$this->const [$r] [3] = 'Oblyon topmenu text color';
 	$this->const [$r] [4] = 1;
 	$this->const [$r] [5] = 'allentities';
@@ -201,7 +201,7 @@ function __construct($db) {
 	$r ++;
 	$this->const [$r] [0] = "OBLYON_COLOR_LEFTMENU_TXT";
 	$this->const [$r] [1] = "chaine";
-	$this->const [$r] [2] = "#f4f4f4";
+	$this->const [$r] [2] = "#F4F4F4";
 	$this->const [$r] [3] = 'Oblyon leftmenu leftmenu hover color';
 	$this->const [$r] [4] = 1;
 	$this->const [$r] [5] = 'allentities';

--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -83,7 +83,7 @@ if (! empty($conf->global->MAIN_OVERWRITE_THEME_RES)) { $path='/'.$conf->global-
 
 $maincolor= $conf->global->OBLYON_COLOR_MAIN; // default value: #0083a2
 $navlinkcolor= '#f4f4f4'; 	// default value: #eee
-$topmenu_hover= '#2ea2cc';	// default value: #2ea2cc
+$topmenu_hover= $maincolor;	// default value: #
 $bgnavtop = $conf->global->OBLYON_COLOR_TOPMENU_BCKGRD; // default value: #333					//	for main navigation
 $bgnavtop_txt = $conf->global->OBLYON_COLOR_TOPMENU_TXT; // default value: #ffffff				//	for main navigation
 $bgnavtop_hover = $conf->global->OBLYON_COLOR_TOPMENU_BCKGRD_HOVER;	// default value: #444		//	for main navigation
@@ -1826,7 +1826,7 @@ div.ficheaddleft {
 
 #tmenu_tooltip .tmenu li:hover .main-nav__link,
 .main-nav__item:hover .main-nav__link {
-	color: #2ea2cc;
+	color: <?php print $topmenu_hover; ?>;
 }
 
 .main-nav__link {
@@ -1981,15 +1981,15 @@ li.item-heading:hover > .sec-nav__link {
 }
 
 .sec-nav.is-inverted li.item-heading:hover .caret--top {
-	border-top-color: #2ea2cc;
+	border-top-color: <?php print $maincolor; ?>;
 }
  
 .sec-nav__sub-list .item-level2:hover .caret--left {
-	border-left-color: #2ea2cc;
+	border-left-color: <?php print $maincolor; ?>;
 }
 
 .sec-nav__sub-list .item-level2:hover .caret--right {
-	border-right-color: #2ea2cc;
+	border-right-color: <?php print $maincolor; ?>;
 }
 
 
@@ -2744,7 +2744,7 @@ div.login a:hover {
 
 .pushy-active .pushy-btn {
 	background-color: #444;
-	color: #2ea2cc;
+	color: <?php print $maincolor; ?>;
 }
 
 <?php } ?> /* end HIDE_LEFTMENU */


### PR DESCRIPTION
Fix the default colors and usage of existing colors.

The initial top menu text hover was blue, with a blue background as well, so pretty much impossible to read.

Also, hard coded colors make the theme a lot less customizable.
