### PR TITLE
:bug: Force minimum width of login block for users with short login

### DIFF
--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -2130,6 +2130,10 @@ div.login_block_user > .classfortooltip.login_block_elem2 {
 	min-width: 120px;
 }
 
+.login_block_other .inline-block {
+	width: 40px;
+}
+
 .login_block:hover > .login_block_other {
 	display: block;
 }

--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -2080,6 +2080,7 @@ div.login_block_user{
 	clear: left;
 	float: <?php print $left; ?>;
 	padding-right: 15px;
+	min-width: 120px;
 }
 
 div.login_block_user .login a,

--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -2127,6 +2127,7 @@ div.login_block_user > .classfortooltip.login_block_elem2 {
 	<?php } ?>
 	height: 40px;
 	line-height: 40px;
+	min-width: 120px;
 }
 
 .login_block:hover > .login_block_other {


### PR DESCRIPTION
The `login_block_other` does not have a minimum width, so when the user has a _short_ login, the previous `login_block` is smaller than the 120px needed to display the 3 buttons on the same line.