### PR TITLE
Menu entries fixes and enhancements

### DIFF
--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -1800,7 +1800,6 @@ div.ficheaddleft {
 		line-height: 54px;
 	<?php } else { ?>
 		height: 54px;
-		min-width: 66px;
 	<?php } ?>
 }
 
@@ -1866,6 +1865,7 @@ div.ficheaddleft {
  
 .main-nav__link.is-disabled {
 	cursor: not-allowed;
+	display: none;
 	opacity: .6;
 }
 .main-nav__link.is-disabled:hover {
@@ -6961,6 +6961,15 @@ img.loginphoto {
 	#tooltip {
 		position: absolute;
 		width: <?php print dol_size(350,'width'); ?>px;
+	}
+
+	#tmenu_tooltip .main-nav__item {
+		max-width: 66px;
+	}
+
+	.main-nav__link {
+		overflow: hidden;
+		text-overflow: ellipsis;
 	}
 }
 

--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -1763,7 +1763,6 @@ div.ficheaddleft {
 		height: <?php print $heightmenu; ?>px;
 	<?php } ?>
 	display: block;
-	height: 40px;
 	margin: 0;
 	padding: 0;
 	position: relative;

--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -2458,6 +2458,7 @@ div.login a:hover {
 
 .sec-nav .sec-nav__link.is-disabled {
 	cursor: not-allowed;
+	display: none;
 }
 
  

--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -6953,22 +6953,87 @@ img.loginphoto {
 {
 	padding: 0 4px 0 4px;
 }
-@media only screen and (max-width: 767px)
-{
-	.imgopensurveywizard { width:95%; height: auto; }
 
-	#tooltip {
-		position: absolute;
-		width: <?php print dol_size(350,'width'); ?>px;
+
+/* rule to reduce inverted top menu */
+@media only screen and (max-width: 1200px)
+{
+	#tmenu_tooltipinvert .sec-nav__item {
+		max-width: 160px;
+	}
+	#tmenu_tooltipinvert .sec-nav__item .icon {
+		font-size: 20px;
+		padding: 0 5px;
+	}
+	.sec-nav__link {
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+}
+
+/* rule to reduce inverted top menu */
+@media only screen and (max-width: 1024px)
+{
+	#tmenu_tooltipinvert .sec-nav__item {
+		max-width: 120px;
+	}
+	#tmenu_tooltipinvert .sec-nav__item .icon {
+		font-size: 24px;
+		padding: 0 5px;
+	}
+	.sec-nav__sub-item {
+		overflow-wrap: break-word;
 	}
 
+
+	div.vmenu {
+		min-width: 170px;
+		width: 170px;
+	}
+	.vmenusearchselectcombo {
+		width: 150px;
+	}
+	.sec-nav.is-inverted {
+		margin-left: 170px;
+	}
+}
+
+/* rule to reduce inverted top menu */
+@media only screen and (max-width: 905px)
+{
+	#tmenu_tooltipinvert .sec-nav__item {
+		max-width: 90px;
+	}
+}
+
+/* rule to reduce top menu */
+@media only screen and (max-width: 767px)
+{
 	#tmenu_tooltip .main-nav__item {
 		max-width: 66px;
 	}
-
 	.main-nav__link {
 		overflow: hidden;
 		text-overflow: ellipsis;
+	}
+
+	#tmenu_tooltipinvert .sec-nav__item {
+		max-width: 80px;
+	}
+	#tmenu_tooltipinvert .sec-nav__item .icon {
+		font-size: 28px;
+		padding: 0 10px;
+	}
+
+	div.vmenu {
+		min-width: 130px;
+		width: 130px;
+	}
+	.vmenusearchselectcombo {
+		width: auto;
+	}
+	.sec-nav.is-inverted {
+		margin-left: 130px;
 	}
 }
 

--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -1864,7 +1864,6 @@ div.ficheaddleft {
  
 .main-nav__link.is-disabled {
 	cursor: not-allowed;
-	display: none;
 	opacity: .6;
 }
 .main-nav__link.is-disabled:hover {
@@ -2457,7 +2456,6 @@ div.login a:hover {
 
 .sec-nav .sec-nav__link.is-disabled {
 	cursor: not-allowed;
-	display: none;
 }
 
  


### PR DESCRIPTION
I do not see any reasons to show entries in the menu that the user cannot access.

From a developer point of view, it makes sense to check if permissions have been applied properly, but it only provides unneeded information to the end user.
Worse, it takes space that would be well needed on smaller devices.
So menu entries are now hidden if disabled (still present in source code though, since this would require a change in Dolibarr itself).

I also added media queries to limit the size of the menu entries. This gives a more responsive design as it shrinks the menus to the bare minimum to either see the icons (inverted mode) or wrap the text.