### PR TITLE
:lipstick: Use same text color for table titles

### DIFF
--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -4464,7 +4464,7 @@ tr.liste_titre_sel,
 form.liste_titre, 
 form.liste_titre_sel {
 	background-color: <?php print $maincolor; ?>;
-	color: #333;
+	color: #f4f4f4;
 	font-family: <?php print $fontboxtitle; ?>;
 	font-size: 1em;
 	font-weight: normal;
@@ -4478,7 +4478,7 @@ tr.liste_titre a,
 tr.liste_titre_sel a, 
 form.liste_titre a, 
 form.liste_titre_sel a {
-	color: #f8f8f8;
+	color: #ffffff;
 }
 
 div.liste_titre_bydiv {


### PR DESCRIPTION
Some table titles were in black, some others were in white... white over the default main color was more readable so changed to white for more consistency.