### PR TITLE
6.0 dropdown

### DIFF
--- a/htdocs/theme/oblyon/style.css.php
+++ b/htdocs/theme/oblyon/style.css.php
@@ -6892,6 +6892,7 @@ dl.dropdown {
 	padding: 0 3px 2px 0;
 }
 .dropdown dd ul {
+	color: #333;
 	background-color: #FFF;
 	border: 1px solid #888;
 	display:none;


### PR DESCRIPTION
Bug introduced by #17.
Fix the dropdown text color without impacting the tables title color.