### PR TITLE
Fix warning on PHP 7.2.10

### DIFF
--- a/htdocs/custom/oblyon/admin/menus.php
+++ b/htdocs/custom/oblyon/admin/menus.php
@@ -103,7 +103,7 @@ $head = oblyon_admin_prepare_head();
 dol_fiche_head ( $head, 'menus', $langs->trans ( "Module113900Name" ), 0, "oblyon@oblyon" );
 
 // Alert
-if (!MAIN_MODULE_OBLYON && $conf->theme!="oblyon")
+if (!defined('MAIN_MODULE_OBLYON') && $conf->theme!="oblyon")
 {
   print '<div class="bloc_warning">';
   print img_warning().' '.$langs->trans('OblyonErrorMessage');    


### PR DESCRIPTION
Tested on PHP 7.2.10 & got the warning below:

![screenshot 2019-02-24 22-52-57](https://user-images.githubusercontent.com/30635693/53306001-eece2480-387f-11e9-92cb-abfa76fed172.png)
