### PR TITLE
info-box: make background gradient take whole height

### DIFF
--- a/htdocs/theme/oblyon/info-box.inc.php
+++ b/htdocs/theme/oblyon/info-box.inc.php
@@ -142,6 +142,7 @@ if (! defined('ISLOADEDBYSTEELSHEET')) die('Must be call by steelsheet'); ?>
 }
 
 .info-box-content {
+	min-height: 80px;
 	padding: 5px 10px;
 	margin-left: 90px;
 }


### PR DESCRIPTION
On module configuration page, the background gradient would not take 100% of the info-box height. This would create a white space at the bottom of the box in some cases (typically when the text takes only one line, or when the box is 100% wide)