### PR TITLE
fix: allow KeepassXC-browser to recognize login input fields as such

### DIFF
--- a/htdocs/theme/oblyon/login.inc.php
+++ b/htdocs/theme/oblyon/login.inc.php
@@ -77,7 +77,6 @@ if (! defined('ISLOADEDBYSTEELSHEET')) die('Must be call by steelsheet'); ?>
         margin-left: 10px;
         margin-top: 5px;
         margin-bottom: 5px;
-		opacity: 0.3;
     }
     .login_table input#username:focus, .login_table input#password:focus, .login_table input#securitycode:focus {
         outline: none !important;


### PR DESCRIPTION
Removing the 'opacity' property for the username login and password form allows KeepassXC-browser to recognize them as input fields and autofill them. I don't understand why.

Issue exposed on the forum : https://www.dolibarr.fr/forum/t/theme-oblyon/22334/72

As a side benefit, one can now see the placeholders that were too dim before.