### PR TITLE
fix ul/ol not being correctly rendered on messages

### DIFF
--- a/htdocs/theme/oblyon/global.inc.php
+++ b/htdocs/theme/oblyon/global.inc.php
@@ -15,7 +15,7 @@ a, abbr, acronym, address, big, cite, code,
 del, dfn, em, img, ins, kbd, q, s, samp,
 small, strike, sub, sup, tt, var,
 b, u, i, center,
-dl, dt, dd, ol, ul, li,
+dl, dt, dd,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
 article, aside, canvas, details, embed,
@@ -36,9 +36,6 @@ footer, header, hgroup, menu, nav, section {
 }
 body {
     line-height: 1;
-}
-ol, ul {
-    list-style: none;
 }
 blockquote, q {
     quotes: none;

--- a/htdocs/theme/oblyon/timeline.inc.php
+++ b/htdocs/theme/oblyon/timeline.inc.php
@@ -20,7 +20,6 @@ if (! defined('ISLOADEDBYSTEELSHEET')) die('Must be call by steelsheet'); ?>
     position: relative;
     margin: 0 0 30px 0;
     padding: 0;
-    list-style: none;
 }
 .timeline:before {
     content: '';
@@ -37,6 +36,7 @@ if (! defined('ISLOADEDBYSTEELSHEET')) die('Must be call by steelsheet'); ?>
     position: relative;
     margin-right: 0;
     margin-bottom: 15px;
+    list-style: none;
 }
 .timeline > li:before,
 .timeline > li:after {


### PR DESCRIPTION
Messages were not correctly rendered:
- on ticket timeline
- on event card
- on public ticket view

![ticket_message_oblyon_FAUX](https://user-images.githubusercontent.com/89838020/156554684-5da9771d-4c7a-459e-9a28-8ec2b623353d.png)

![ticket_message_oblyon_ok](https://user-images.githubusercontent.com/89838020/156555335-c656a966-ff81-4ba1-bb34-4328f60a20bf.png)


This is due to `ul, ol` list-style being `none`. and `ul, ol, li` margin being 0. I removed these properties from global.inc.php.
However, this breaks display for the events list (bullets are displayed), so I added `list-style=none` in .timeline > li.

As far as I can see, clearing `ul, ol` style does not break anything else than timeline in the interface. Moreover, list-style for `ol, ul` is default in eldy theme, so I guess this is fine. I checked it on many screens, but I might have missed something.
