### PR TITLE
fix: remove bullets before submenu list when menus are inverted

### DIFF
--- a/htdocs/theme/oblyon/global.inc.php
+++ b/htdocs/theme/oblyon/global.inc.php
@@ -2426,6 +2426,7 @@ li.sec-nav__sub-item:focus, li.sec-nav__sub-item sec-nav__link:focus {
     background-color: <?php print $bgnavleft; ?>;
     box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.055);
     display: none;
+    list-style: none;
     opacity: 0;
     padding-top: 0;
     padding-bottom: 5px;


### PR DESCRIPTION
Bullets were visible before submenu lists:
![oblyon_puces](https://user-images.githubusercontent.com/89838020/160128413-c15fea7a-0e0c-4edf-baab-df33a7b7989c.png)

This PR corrects these _points_ (pun intended ;-) ) but **keeps** bullets before submenu items when menus are **not inverted**:
![remaining_bullets](https://user-images.githubusercontent.com/89838020/160128625-60459969-d2a8-4ba5-b8a8-3f156bc30a2a.png)

