### PR TITLE
Fix topmenu-login-dropdown when using some external modules

### DIFF
--- a/htdocs/theme/oblyon/dropdown.inc.php
+++ b/htdocs/theme/oblyon/dropdown.inc.php
@@ -81,7 +81,7 @@ if (! defined('ISLOADEDBYSTEELSHEET')) die('Must be call by steelsheet'); ?>
 .tmenu .dropdown-menu, .login_block .dropdown-menu {
     position: absolute;
     right: 0;
-    left: -120px;
+    left: auto;
     line-height:1.3em;
 }
 .tmenu .dropdown-menu, .login_block  .dropdown-menu .user-body {

--- a/htdocs/theme/oblyon/global.inc.php
+++ b/htdocs/theme/oblyon/global.inc.php
@@ -2811,7 +2811,7 @@ div.login_block_user {
 	display: inline-block;
 	vertical-align: middle;
     /*clear: left;*/
-    float: <?php print $left; ?>;
+    /*float: <?php print $left; ?>;*/
     margin-right: 0px;
 }
 


### PR DESCRIPTION
With some external modules like MBI calls, InfraSSearch the top menu login dropdown doesn't stay at the very right of the top menu.