### PR TITLE
Fix: the setup menu was accessible for unpriviledged users

### DIFF
--- a/htdocs/custom/oblyon/core/menus/standard/oblyon.lib.php
+++ b/htdocs/custom/oblyon/core/menus/standard/oblyon.lib.php
@@ -775,7 +775,7 @@ function print_left_oblyon_menu($db, $menu_array_before, $menu_array_after, &$ta
 
             if (! empty($menu_invert)) $leftmenu= 'setup';
 
-			if ($usemenuhider || empty($leftmenu) || $leftmenu == "setup") {
+			if (!empty($user->admin) && ($usemenuhider || empty($leftmenu) || $leftmenu == "setup")) {
 				// Load translation files required by the page
 				$langs->loadLangs(array("admin", "help"));
 


### PR DESCRIPTION
Fix : the setup menu was accessible for unpriviledged users under dashboard dropdown.

Here is an example with unpriviledged user:
![Capture d’écran du 2022-11-08 17-07-04](https://user-images.githubusercontent.com/89838020/200619722-6ebef776-4058-460e-b734-ed26a1708907.png)
