### PR TITLE
Fix messages boxes being too large

### DIFF
--- a/htdocs/theme/oblyon/global.inc.php
+++ b/htdocs/theme/oblyon/global.inc.php
@@ -1629,6 +1629,11 @@ select.selectarrowonleft option {
     direction: ltr;
 }
 
+/* To avoid message boxes being too large because code not wrapping */
+.longmessagecut pre {
+    white-space: break-spaces;
+}
+
 /* ============================================================================== */
 /* Styles to hide objects														  */
 /* ============================================================================== */


### PR DESCRIPTION
When long lines are present in messages `<pre>` tag  (such as errors), the mesage is very large and overflows the browsers window.

![image](https://user-images.githubusercontent.com/89838020/220661060-54b5424a-340b-4601-90f1-783c46741336.png)
