### PR TITLE
First line is hidden on popup

### DIFF
--- a/htdocs/theme/oblyon/global.inc.php
+++ b/htdocs/theme/oblyon/global.inc.php
@@ -9634,6 +9634,9 @@ tr.liste_titre th {
 	background-color: <?php print $colorbtitle; ?>;
 	z-index: 1;
 }
+form.ui-dialog-content tr.liste_titre th {
+	top: unset !important;
+}
 <?php } ?>
 
 /* ============================================================================== */


### PR DESCRIPTION
Hello my friend,

If your enable the hidden feature MAIN_ENABLE_IMPORT_LINKED_OBJECT_LINES you may find a button near the links object 
![Oblyon fix 1](https://github.com/aspangaro/oblyon/assets/23272229/14e7ca49-1dfc-406d-81e7-7c589946487a)

With this you can import lines from the linked object thru a popup ; but the first row of the array of available rows is hidden by the header !

Greetings,
Sylvain.
