### PR TITLE
Define NOLOGIN on custom.css.php

### DIFF
--- a/htdocs/theme/oblyon/custom.css.php
+++ b/htdocs/theme/oblyon/custom.css.php
@@ -17,6 +17,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+define('NOLOGIN', 1); // Allow the use of the custom CSS on public pages like tickets
+
 $res														        = 0;
 if (! $res && file_exists("../main.inc.php"))		$res	= @include "../main.inc.php";
 if (! $res && file_exists("../../main.inc.php"))	$res	= @include "../../main.inc.php";


### PR DESCRIPTION
On public pages like tickets, the `custom.css.php` redirect to log in and hang the page load.

*This should be backport to the 2024 branch once merge*