### PR TITLE
FIX : the link of HOME logo is not correct. #170

### DIFF
--- a/core/menus/standard/oblyon.lib.php
+++ b/core/menus/standard/oblyon.lib.php
@@ -52,11 +52,10 @@ function print_oblyon_menu($db, $atarget, $type_user = 0, &$tabMenu, &$menu, $no
 	$leftmenu = (empty($_SESSION["leftmenu"]) ? '' : $_SESSION["leftmenu"]);
 
 	$landingpage = (!getDolUserString('MAIN_LANDING_PAGE') ? (!getDolGlobalString('MAIN_LANDING_PAGE') ? '' : getDolGlobalString('MAIN_LANDING_PAGE')) : getDolUserString('MAIN_LANDING_PAGE'));
-	if (! empty($landingpage)) {
-		$landingpage = dol_buildpath($landingpage, 1);
-	} else {
-		$landingpage = DOL_URL_ROOT . '/index.php?mainmenu=home&amp;leftmenu=home';
+	if (empty($landingpage)) {
+		$landingpage = '/index.php?mainmenu=home&amp;leftmenu=home';
 	}
+	$landingpage = dol_buildpath($landingpage, 1);
 
 	$id = 'mainmenu';
 	$listofmodulesforexternal = explode(',', getDolGlobalString('MAIN_MODULES_FOR_EXTERNAL'));


### PR DESCRIPTION
# FIX : the link of HOME logo is not correct.

issue #170 is not fixed yet.

Problem : when MAIN_LANDING_PAGE is not defined and DOL_URL_ROOT is eg. `/doliprod`: 
- the company logo targets to `/doliprod/doliprod/index.php` (incorrect)
- the HOME icon targets to `/doliprod/index.php` (correct)

seen on oblyon 3.0.6.

This PR fixes this behavior.