### PR TITLE
NEW const MENU_HIDE_EMAIL_TEMPLATES to hide email templates setup in Tools menu

### DIFF
--- a/core/menus/standard/oblyon.lib.php
+++ b/core/menus/standard/oblyon.lib.php
@@ -2023,7 +2023,7 @@ function print_left_oblyon_menu($db, $menu_array_before, $menu_array_after, &$ta
 		 * Menu TOOLS
 		 */
 		if ($mainmenu == 'tools') {
-            if (empty($user->socid)) { // limit to internal users
+            if (!getDolGlobalInt('MENU_HIDE_EMAIL_TEMPLATES') && empty($user->socid)) { // limit to internal users
                 $langs->load("mails");
                 $newmenu->add("/admin/mails_templates.php?leftmenu=email_templates", $langs->trans("EMailTemplates"), 0, 1, '', $mainmenu, 'email_templates', 0);
             }


### PR DESCRIPTION
NEW const MENU_HIDE_EMAIL_TEMPLATES to hide email templates setup in Tools menu
- see PR 35739 on Dolibarr : https://github.com/Dolibarr/dolibarr/pull/35739